### PR TITLE
Add VSCode Checkstyle for Java configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "java.checkstyle.configuration": "${workspaceFolder}/checks.xml",
+    "java.checkstyle.version": "9.1",
+    "java.checkstyle.properties": {
+        "basedir": "${workspaceFolder}/src/main/java/frc/robot"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@ Some additional naming guidance:
  * Variable names: camelCase
  * Booleans should start with "is" or "has" (ex. hasMotor, isPositive)
 
+The full style guidelines are enforced by [CheckStyle](https://checkstyle.sourceforge.io/). You may wish to install the [VSCode Checkstyle for Java plugin](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle) to automatically detect style errors.
+
 ## Commit messages
 Everyone should read and follow the rules in "[How to write a Git Commit Message](https://chris.beams.io/posts/git-commit/)."


### PR DESCRIPTION
Add configuration settings to enable running the Checkstyle for Java plugin in VSCode. This should enable automatic style checking from within VSCode.